### PR TITLE
Add admin auth, API clients and admin UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5001/api

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,21 +1,47 @@
 import './App.css'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import { LanguageProvider } from './context/LanguageContext'
+import { AdminAuthProvider, useAdminAuth } from './context/AdminAuthContext'
 import Homepage from './Pages/Homepage'
 import Adminpanel from './Pages/Adminpanel'
 import BlogReader from './Pages/BlogReader'
+import AdminSignIn from './Pages/AdminSignIn'
+
+function ProtectedAdminRoute() {
+  const location = useLocation()
+  const { isAuthenticated, isCheckingSession } = useAdminAuth()
+
+  if (isCheckingSession) {
+    return (
+      <div className="min-h-screen bg-slate-100 flex items-center justify-center text-slate-700">
+        Checking admin session...
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/admin/sign-in" replace state={{ from: location }} />
+  }
+
+  return <Outlet />
+}
 
 function App() {
   return (
-    <LanguageProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Homepage />} />
-          <Route path="/blogs/:slug" element={<BlogReader />} />
-          <Route path="/admin/*" element={<Adminpanel />} />
-        </Routes>
-      </BrowserRouter>
-    </LanguageProvider>
+    <AdminAuthProvider>
+      <LanguageProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Homepage />} />
+            <Route path="/blogs/:slug" element={<BlogReader />} />
+            <Route path="/admin/sign-in" element={<AdminSignIn />} />
+            <Route element={<ProtectedAdminRoute />}>
+              <Route path="/admin/*" element={<Adminpanel />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </LanguageProvider>
+    </AdminAuthProvider>
   )
 }
 

--- a/src/Pages/AdminSignIn.jsx
+++ b/src/Pages/AdminSignIn.jsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { useAdminAuth } from '../context/AdminAuthContext'
+
+export default function AdminSignIn() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { isAuthenticated, signIn } = useAdminAuth()
+
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const redirectPath = location.state?.from?.pathname || '/admin'
+
+  if (isAuthenticated) {
+    return <Navigate to={redirectPath} replace />
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+
+    const result = await signIn(username, password)
+
+    if (!result.success) {
+      setError(result.message)
+      setIsSubmitting(false)
+      return
+    }
+
+    setError('')
+    setIsSubmitting(false)
+    navigate(redirectPath, { replace: true })
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-100 text-slate-900 relative overflow-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-20 -left-20 h-72 w-72 rounded-full bg-fuchsia-500/20 blur-3xl" />
+        <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-purple-500/20 blur-3xl" />
+      </div>
+
+      <main className="relative min-h-screen flex items-center justify-center px-4 py-10 sm:px-6">
+        <motion.section
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.45, ease: 'easeOut' }}
+          className="w-full max-w-md rounded-2xl bg-white border border-slate-200 shadow-xl p-7 sm:p-8"
+        >
+          <div className="mb-6">
+            <p className="text-xs uppercase tracking-[0.24em] text-slate-500">Flashboard Admin</p>
+            <h1 className="text-3xl font-black mt-2 bg-gradient-to-r from-[#b000ff] to-[#ff0f78] bg-clip-text text-transparent">
+              Sign In
+            </h1>
+            <p className="text-slate-600 text-sm mt-2">
+              Sign in to manage blog categories, topics, and content.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="username" className="block text-sm font-semibold text-slate-700 mb-1.5">
+                Username
+              </label>
+              <input
+                id="username"
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                autoComplete="username"
+                placeholder="Enter username"
+                className="w-full px-4 py-2.5 rounded-xl border border-slate-300 bg-white focus:outline-none focus:ring-2 focus:ring-fuchsia-500/50"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-semibold text-slate-700 mb-1.5">
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
+                placeholder="Enter password"
+                className="w-full px-4 py-2.5 rounded-xl border border-slate-300 bg-white focus:outline-none focus:ring-2 focus:ring-fuchsia-500/50"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+                {error}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full px-4 py-2.5 rounded-xl text-white font-semibold bg-gradient-to-r from-[#b000ff] to-[#ff0f78] hover:shadow-lg transition"
+            >
+              {isSubmitting ? 'Signing In...' : 'Sign In to Admin Panel'}
+            </button>
+          </form>
+
+          <div className="mt-6 text-xs text-slate-500 border-t border-slate-200 pt-4 space-y-2">
+            <p>Use your admin credentials configured in the backend service.</p>
+            <p>API base URL is controlled by VITE_API_BASE_URL in your frontend .env file.</p>
+          </div>
+
+          <Link
+            to="/"
+            className="inline-flex mt-5 text-sm font-semibold text-slate-700 hover:text-slate-900"
+          >
+            ← Back to Homepage
+          </Link>
+        </motion.section>
+      </main>
+    </div>
+  )
+}

--- a/src/Pages/Adminpanel.jsx
+++ b/src/Pages/Adminpanel.jsx
@@ -1,7 +1,67 @@
-import { useState } from 'react'
-import { Routes, Route, useNavigate } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import ReactQuill from 'react-quill-new'
 import 'react-quill-new/dist/quill.snow.css'
+import { useAdminAuth } from '../context/AdminAuthContext'
+import {
+  createBlog,
+  createCategory,
+  createTopic,
+  deleteBlog,
+  getBlogs,
+  getCategories,
+  getTopics,
+  uploadAdminImage,
+  updateBlog
+} from '../lib/adminApi'
+import { getEntityId } from '../lib/apiClient'
+
+function normalizeBlog(blog) {
+  if (!blog) {
+    return null
+  }
+
+  return {
+    ...blog,
+    id: getEntityId(blog),
+    title: blog.title || blog.en?.title || '',
+    titleSi: blog.titleSi || blog.si?.title || '',
+    content: blog.content || blog.en?.body || '',
+    contentSi: blog.contentSi || blog.si?.body || '',
+    category: blog.category || blog.en?.category || '',
+    categorySi: blog.categorySi || blog.si?.category || '',
+    topic: blog.topic || blog.en?.topic || '',
+    topicSi: blog.topicSi || blog.si?.topic || '',
+    date: blog.date || blog.createdAt || '',
+    image: blog.image || blog.en?.image || null
+  }
+}
+
+function normalizeCategory(category) {
+  if (!category) {
+    return null
+  }
+
+  return {
+    ...category,
+    id: getEntityId(category),
+    en: category.en || category.name || category.title || category.nameEn || '',
+    si: category.si || category.nameSi || ''
+  }
+}
+
+function normalizeTopic(topic) {
+  if (!topic) {
+    return null
+  }
+
+  return {
+    ...topic,
+    id: getEntityId(topic),
+    en: topic.en || topic.name || topic.title || topic.nameEn || '',
+    si: topic.si || topic.nameSi || ''
+  }
+}
 
 // Blog View Component
 function BlogView({ blog, onBack }) {
@@ -172,17 +232,14 @@ function Dashboard({ blogs, categories, onDeleteBlog, onEditBlog, onNavigateToCr
   )
 }
 
-// Rich Text Editor Modules
-const quillModules = {
-  toolbar: [
-    ['bold', 'italic', 'underline', 'strike'],
-    ['blockquote', 'code-block'],
-    [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }],
-    [{ 'list': 'ordered' }, { 'list': 'bullet' }],
-    ['link', 'image'],
-    ['clean']
-  ]
-}
+const quillToolbar = [
+  ['bold', 'italic', 'underline', 'strike'],
+  ['blockquote', 'code-block'],
+  [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }],
+  [{ 'list': 'ordered' }, { 'list': 'bullet' }],
+  ['link', 'image'],
+  ['clean']
+]
 
 const quillFormats = [
   'bold', 'italic', 'underline', 'strike',
@@ -193,7 +250,7 @@ const quillFormats = [
 ]
 
 // Create/Edit Blog Component
-function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, editingBlog, onAddTopic, onAddCategory }) {
+function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, editingBlog, onAddTopic, onAddCategory, token }) {
   const initialForm = {
     title: '',
     titleSi: '',
@@ -208,9 +265,7 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
     topicSi: '',
     newTopic: '',
     newTopicSi: '',
-    useNewTopic: false,
-    image: null,
-    imagePreview: null
+    useNewTopic: false
   }
 
   const [formData, setFormData] = useState(() =>
@@ -219,11 +274,76 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
           ...initialForm,
           ...editingBlog,
           categorySi: editingBlog.categorySi || editingBlog.category || '',
-          topicSi: editingBlog.topicSi || editingBlog.topic || '',
-          imagePreview: editingBlog.image || null
+          topicSi: editingBlog.topicSi || editingBlog.topic || ''
         }
       : initialForm
   )
+  const [uploadingEditor, setUploadingEditor] = useState('')
+  const englishEditorRef = useRef(null)
+  const sinhalaEditorRef = useRef(null)
+
+  const insertUploadedImage = async (file, editorRef, editorLabel) => {
+    if (!file) {
+      return
+    }
+
+    if (!file.type.startsWith('image/')) {
+      alert('Please select a valid image file.')
+      return
+    }
+
+    setUploadingEditor(editorLabel)
+
+    try {
+      const uploadedImage = await uploadAdminImage(file, token)
+      const quill = editorRef.current?.getEditor()
+
+      if (!quill) {
+        throw new Error('Editor is not ready. Please try again.')
+      }
+
+      const selection = quill.getSelection(true)
+      const index = selection ? selection.index : quill.getLength()
+
+      quill.insertEmbed(index, 'image', uploadedImage.url, 'user')
+      quill.setSelection(index + 1)
+    } catch (error) {
+      alert(error.message || 'Failed to upload image')
+    } finally {
+      setUploadingEditor('')
+    }
+  }
+
+  const openImagePicker = (editorRef, editorLabel) => {
+    const input = document.createElement('input')
+    input.setAttribute('type', 'file')
+    input.setAttribute('accept', 'image/*')
+
+    input.onchange = async () => {
+      const selectedFile = input.files?.[0]
+      await insertUploadedImage(selectedFile, editorRef, editorLabel)
+    }
+
+    input.click()
+  }
+
+  const quillModulesEn = {
+    toolbar: {
+      container: quillToolbar,
+      handlers: {
+        image: () => openImagePicker(englishEditorRef, 'English')
+      }
+    }
+  }
+
+  const quillModulesSi = {
+    toolbar: {
+      container: quillToolbar,
+      handlers: {
+        image: () => openImagePicker(sinhalaEditorRef, 'Sinhala')
+      }
+    }
+  }
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target
@@ -267,22 +387,7 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
     }))
   }
 
-  const handleImageChange = (e) => {
-    const file = e.target.files[0]
-    if (file) {
-      const reader = new FileReader()
-      reader.onloadend = () => {
-        setFormData(prev => ({
-          ...prev,
-          image: reader.result,
-          imagePreview: reader.result
-        }))
-      }
-      reader.readAsDataURL(file)
-    }
-  }
-
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
     
     const categoryEn = formData.useNewCategory ? formData.newCategory.trim() : formData.category.trim()
@@ -311,11 +416,6 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
       return
     }
 
-    if (!formData.image) {
-      alert('Please add a featured image')
-      return
-    }
-
     // Add new category if creating one
     if (formData.useNewCategory && formData.newCategory.trim()) {
       onAddCategory({
@@ -332,7 +432,7 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
       })
     }
 
-    onSaveBlog({
+    const didSave = await onSaveBlog({
       id: editingBlog?.id || Date.now(),
       title: formData.title,
       titleSi: formData.titleSi,
@@ -342,11 +442,12 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
       categorySi,
       topic: topicEn,
       topicSi,
-      date: editingBlog?.date || new Date().toLocaleDateString(),
-      image: formData.image
+      date: editingBlog?.date || new Date().toLocaleDateString()
     })
 
-    onNavigateToDashboard()
+    if (didSave) {
+      onNavigateToDashboard()
+    }
   }
 
   return (
@@ -394,14 +495,18 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
             </label>
             <div className="border border-gray-300 rounded-lg overflow-hidden">
               <ReactQuill
+                ref={englishEditorRef}
                 theme="snow"
                 value={formData.content}
                 onChange={handleContentChange}
-                modules={quillModules}
+                modules={quillModulesEn}
                 formats={quillFormats}
                 placeholder="Write your blog content here. Use formatting tools to add subtopics, images, lists, etc."
               />
             </div>
+            {uploadingEditor === 'English' ? (
+              <p className="text-xs text-slate-500 mt-2">Uploading image to S3...</p>
+            ) : null}
           </div>
 
           {/* Sinhala Content - Rich Text Editor */}
@@ -411,14 +516,18 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
             </label>
             <div className="border border-gray-300 rounded-lg overflow-hidden">
               <ReactQuill
+                ref={sinhalaEditorRef}
                 theme="snow"
                 value={formData.contentSi}
                 onChange={handleContentChangeSi}
-                modules={quillModules}
+                modules={quillModulesSi}
                 formats={quillFormats}
                 placeholder="සිංහල අන්තර්ගතය මෙහි ලියන්න"
               />
             </div>
+            {uploadingEditor === 'Sinhala' ? (
+              <p className="text-xs text-slate-500 mt-2">Uploading image to S3...</p>
+            ) : null}
           </div>
 
           {/* Category Selection with new category option */}
@@ -529,41 +638,6 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
             </div>
           </div>
 
-          {/* Image Upload */}
-          <div>
-            <label className="block text-sm font-semibold text-gray-700 mb-2">
-              Featured Image *
-            </label>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={handleImageChange}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
-            />
-            {formData.imagePreview && (
-              <div className="mt-4 rounded-lg overflow-hidden border border-gray-200">
-                <img
-                  src={formData.imagePreview}
-                  alt="Preview"
-                  className="w-full h-48 object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={() =>
-                    setFormData(prev => ({
-                      ...prev,
-                      image: null,
-                      imagePreview: null
-                    }))
-                  }
-                  className="w-full mt-2 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
-                >
-                  Remove Image
-                </button>
-              </div>
-            )}
-          </div>
-
           {/* Form Actions */}
           <div className="flex gap-4 justify-end pt-6 border-t border-gray-200">
             <button
@@ -588,38 +662,66 @@ function CreateBlog({ categories, topics, onSaveBlog, onNavigateToDashboard, edi
 
 // Main Admin Panel Component
 export default function Adminpanel() {
+  const navigate = useNavigate()
+  const { signOut, token } = useAdminAuth()
   const [currentView, setCurrentView] = useState('dashboard')
   const [viewingBlog, setViewingBlog] = useState(null)
-  const [blogs, setBlogs] = useState([
-    {
-      id: 1,
-      title: 'Getting Started with FlashBoard',
-      content: 'Learn the basics of FlashBoard in this comprehensive guide...',
-      category: 'Getting Started',
-      topic: 'Basics',
-      date: '2024-01-15',
-      image: null
-    }
-  ])
-  const [categories, setCategories] = useState([
-    { en: 'Getting Started', si: 'ඇරඹේ ගමන් ගිය' },
-    { en: 'Product Updates', si: 'නිෂ්පාදන යාවත්කාලයන්' },
-    { en: 'Authoring Tools', si: 'කතුවැඩි මෙවලම්' },
-    { en: 'Engagement', si: 'සම්බන්ධතා' },
-    { en: 'Integrations', si: 'ඒකීකරණ' },
-    { en: 'Success Stories', si: 'සාර්ථක කතා' }
-  ])
-  const [topics, setTopics] = useState([
-    { en: 'Basics', si: 'මූලික කරුණු' },
-    { en: 'Advanced', si: 'උසස්' },
-    { en: 'Tips & Tricks', si: 'ඉඟි සහ උපකරණ' },
-    { en: 'Tutorials', si: 'නිබන්ධන' }
-  ])
+  const [blogs, setBlogs] = useState([])
+  const [categories, setCategories] = useState([])
+  const [topics, setTopics] = useState([])
   const [editingBlog, setEditingBlog] = useState(null)
+  const [isLoadingData, setIsLoadingData] = useState(true)
+  const [loadError, setLoadError] = useState('')
 
-  const handleDeleteBlog = (id) => {
+  useEffect(() => {
+    let isMounted = true
+
+    const loadAdminData = async () => {
+      setIsLoadingData(true)
+      setLoadError('')
+
+      try {
+        const [blogsData, categoriesData, topicsData] = await Promise.all([
+          getBlogs(),
+          getCategories(),
+          getTopics()
+        ])
+
+        if (!isMounted) {
+          return
+        }
+
+        setBlogs(blogsData.map(normalizeBlog).filter(Boolean))
+        setCategories(categoriesData.map(normalizeCategory).filter(Boolean))
+        setTopics(topicsData.map(normalizeTopic).filter(Boolean))
+      } catch (error) {
+        if (!isMounted) {
+          return
+        }
+
+        setLoadError(error.message || 'Failed to load admin data')
+      } finally {
+        if (isMounted) {
+          setIsLoadingData(false)
+        }
+      }
+    }
+
+    loadAdminData()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const handleDeleteBlog = async (id) => {
     if (confirm('Are you sure you want to delete this blog?')) {
-      setBlogs(blogs.filter(blog => blog.id !== id))
+      try {
+        await deleteBlog(id, token)
+        setBlogs((prevBlogs) => prevBlogs.filter((blog) => getEntityId(blog) !== id))
+      } catch (error) {
+        alert(error.message || 'Failed to delete blog')
+      }
     }
   }
 
@@ -632,29 +734,71 @@ export default function Adminpanel() {
     setViewingBlog(blog)
   }
 
-  const handleSaveBlog = (blogData) => {
-    if (editingBlog) {
-      // Update existing blog
-      setBlogs(blogs.map(blog =>
-        blog.id === blogData.id ? blogData : blog
-      ))
-      setEditingBlog(null)
-    } else {
-      // Add new blog
-      setBlogs([...blogs, blogData])
+  const handleSaveBlog = async (blogData) => {
+    const payload = {
+      title: blogData.title,
+      titleSi: blogData.titleSi,
+      content: blogData.content,
+      contentSi: blogData.contentSi,
+      category: blogData.category,
+      categorySi: blogData.categorySi,
+      topic: blogData.topic,
+      topicSi: blogData.topicSi,
+      date: blogData.date,
+      image: blogData.image || null
+    }
+
+    try {
+      if (editingBlog) {
+        const blogId = getEntityId(editingBlog)
+        const updatedBlog = await updateBlog(blogId, payload, token)
+
+        setBlogs((prevBlogs) =>
+          prevBlogs.map((blog) => (getEntityId(blog) === blogId ? normalizeBlog(updatedBlog || { ...blog, ...payload }) : blog))
+        )
+
+        setEditingBlog(null)
+      } else {
+        const createdBlog = await createBlog(payload, token)
+        setBlogs((prevBlogs) => [...prevBlogs, normalizeBlog(createdBlog || payload)])
+      }
+
+      return true
+    } catch (error) {
+      alert(error.message || 'Failed to save blog')
+      return false
     }
   }
 
-  const handleAddTopic = (newTopic) => {
-    if (!topics.find(t => t.en === newTopic.en)) {
-      setTopics([...topics, newTopic])
+  const handleAddTopic = async (newTopic) => {
+    if (topics.find((t) => t.en === newTopic.en)) {
+      return
+    }
+
+    try {
+      const createdTopic = await createTopic(newTopic, token)
+      setTopics((prevTopics) => [...prevTopics, normalizeTopic(createdTopic || newTopic)])
+    } catch (error) {
+      alert(error.message || 'Failed to create topic')
     }
   }
 
-  const handleAddCategory = (newCategory) => {
-    if (!categories.find(c => c.en === newCategory.en)) {
-      setCategories([...categories, newCategory])
+  const handleAddCategory = async (newCategory) => {
+    if (categories.find((c) => c.en === newCategory.en)) {
+      return
     }
+
+    try {
+      const createdCategory = await createCategory(newCategory, token)
+      setCategories((prevCategories) => [...prevCategories, normalizeCategory(createdCategory || newCategory)])
+    } catch (error) {
+      alert(error.message || 'Failed to create category')
+    }
+  }
+
+  const handleSignOut = () => {
+    signOut()
+    navigate('/admin/sign-in', { replace: true })
   }
 
   // If viewing a blog, show the blog view instead
@@ -670,6 +814,31 @@ export default function Adminpanel() {
     )
   }
 
+  if (isLoadingData) {
+    return (
+      <div className="min-h-screen bg-slate-100 flex items-center justify-center text-slate-700">
+        Loading admin data...
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen bg-slate-100 flex items-center justify-center px-4">
+        <div className="max-w-lg w-full rounded-xl border border-red-200 bg-white p-6 text-center shadow-sm">
+          <p className="text-red-600 font-semibold">Failed to load admin data</p>
+          <p className="text-slate-600 text-sm mt-2">{loadError}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-4 px-4 py-2 rounded-lg bg-slate-900 text-white font-semibold"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="min-h-screen bg-slate-50 flex flex-col">
       {/* Admin Header */}
@@ -680,12 +849,20 @@ export default function Adminpanel() {
               <h1 className="text-3xl font-black tracking-wide">Admin Panel</h1>
               <p className="text-sm opacity-90 mt-1">Manage your blogs and categories</p>
             </div>
-            <a
-              href="/"
-              className="px-4 py-2 bg-white text-purple-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors"
-            >
-              ← Back to Site
-            </a>
+            <div className="flex items-center gap-2">
+              <a
+                href="/"
+                className="px-4 py-2 bg-white text-purple-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors"
+              >
+                ← Back to Site
+              </a>
+              <button
+                onClick={handleSignOut}
+                className="px-4 py-2 bg-slate-900/15 text-white font-semibold rounded-lg hover:bg-slate-900/30 transition-colors"
+              >
+                Sign Out
+              </button>
+            </div>
           </div>
         </div>
       </header>
@@ -727,7 +904,7 @@ export default function Adminpanel() {
           <Dashboard
             blogs={blogs}
             categories={categories}
-            onDeleteBlog={handleDeleteBlog}
+            onDeleteBlog={(blogId) => handleDeleteBlog(blogId)}
             onEditBlog={handleEditBlog}
             onNavigateToCreate={() => setCurrentView('create')}
             onViewBlog={handleViewBlog}
@@ -741,6 +918,7 @@ export default function Adminpanel() {
             editingBlog={editingBlog}
             onAddTopic={handleAddTopic}
             onAddCategory={handleAddCategory}
+            token={token}
           />
         )}
       </main>

--- a/src/Pages/BlogReader.jsx
+++ b/src/Pages/BlogReader.jsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate, useParams, Link } from 'react-router-dom'
 import { useLanguage } from '../context/LanguageContext'
 import { getTranslation } from '../translations/translations'
 import { gradientText, knowledgeSections, knowledgeArticles } from '../data/knowledgeBase'
+import { getPublicArticle, getPublicBlogByIdentifier, getPublicBlogSections, getPublicTopics } from '../lib/publicApi'
 
 const fallbackBody = {
   si: `
@@ -21,7 +22,57 @@ export default function BlogReader() {
   const location = useLocation()
   const { language, switchLanguage } = useLanguage()
   const t = (key) => getTranslation(language, key)
-  const sections = knowledgeSections[language]
+  const [sections, setSections] = useState(knowledgeSections[language])
+  const [backendBlog, setBackendBlog] = useState(null)
+  const [backendArticle, setBackendArticle] = useState(null)
+  const [isLoadingArticle, setIsLoadingArticle] = useState(true)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadReaderData = async () => {
+      setIsLoadingArticle(true)
+
+      const [blogSectionsResult, topicsResult, blogResult, articleResult] = await Promise.allSettled([
+        getPublicBlogSections(language),
+        getPublicTopics(language),
+        getPublicBlogByIdentifier(slug, language),
+        getPublicArticle(slug, language)
+      ])
+
+      if (!isMounted) {
+        return
+      }
+
+      if (blogSectionsResult.status === 'fulfilled' && blogSectionsResult.value.length > 0) {
+        setSections(blogSectionsResult.value)
+      } else if (topicsResult.status === 'fulfilled' && topicsResult.value.length > 0) {
+        setSections(topicsResult.value)
+      } else {
+        setSections(knowledgeSections[language])
+      }
+
+      if (blogResult.status === 'fulfilled') {
+        setBackendBlog(blogResult.value)
+      } else {
+        setBackendBlog(null)
+      }
+
+      if (articleResult.status === 'fulfilled') {
+        setBackendArticle(articleResult.value)
+      } else {
+        setBackendArticle(null)
+      }
+
+      setIsLoadingArticle(false)
+    }
+
+    loadReaderData()
+
+    return () => {
+      isMounted = false
+    }
+  }, [slug, language])
 
   const flatNav = useMemo(
     () =>
@@ -32,6 +83,14 @@ export default function BlogReader() {
   )
 
   const article = useMemo(() => {
+    if (backendBlog) {
+      return backendBlog
+    }
+
+    if (backendArticle) {
+      return backendArticle
+    }
+
     if (knowledgeArticles[slug]) {
       return knowledgeArticles[slug][language]
     }
@@ -48,16 +107,20 @@ export default function BlogReader() {
       image: null,
       body: fallbackBody[language]
     }
-  }, [slug, flatNav, location.state, language, t])
+  }, [backendBlog, backendArticle, slug, flatNav, location.state, language, t])
 
   const related = useMemo(
     () => flatNav.filter((item) => item.category === article.category && item.slug !== slug),
     [article.category, slug, flatNav]
   )
 
-  const activeImage =
-    article.image ||
-    'https://images.unsplash.com/photo-1473186578172-c141e6798cf4?auto=format&fit=crop&w=1400&q=80'
+  if (isLoadingArticle) {
+    return (
+      <div className="min-h-screen bg-slate-100 flex items-center justify-center text-slate-700">
+        Loading article...
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-slate-100">
@@ -152,10 +215,12 @@ export default function BlogReader() {
               ) : null}
             </div>
 
-            <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-50">
-              <div className="absolute inset-0 bg-gradient-to-r from-black/10 via-black/5 to-transparent" />
-              <img src={activeImage} alt={article.title} className="w-full h-[320px] object-cover" />
-            </div>
+            {article.image ? (
+              <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-50">
+                <div className="absolute inset-0 bg-gradient-to-r from-black/10 via-black/5 to-transparent" />
+                <img src={article.image} alt={article.title} className="w-full h-[320px] object-cover" />
+              </div>
+            ) : null}
 
             <section className="prose prose-slate max-w-none text-base leading-relaxed">
               <div

--- a/src/Pages/Homepage.jsx
+++ b/src/Pages/Homepage.jsx
@@ -1,13 +1,57 @@
 import { Link } from 'react-router-dom'
+import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import { useLanguage } from '../context/LanguageContext'
 import { getTranslation } from '../translations/translations'
 import { gradientText, knowledgeSections } from '../data/knowledgeBase'
+import { getPublicBlogSections, getPublicTopics } from '../lib/publicApi'
 
 export default function Homepage() {
   const { language, switchLanguage } = useLanguage()
   const t = (key) => getTranslation(language, key)
-  const sections = knowledgeSections[language]
+  const [sections, setSections] = useState(knowledgeSections[language])
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadTopics = async () => {
+      try {
+        const blogSections = await getPublicBlogSections(language)
+
+        if (!isMounted) {
+          return
+        }
+
+        if (blogSections.length > 0) {
+          setSections(blogSections)
+          return
+        }
+
+        const backendSections = await getPublicTopics(language)
+
+        if (!isMounted) {
+          return
+        }
+
+        if (backendSections.length > 0) {
+          setSections(backendSections)
+          return
+        }
+
+        setSections(knowledgeSections[language])
+      } catch {
+        if (isMounted) {
+          setSections(knowledgeSections[language])
+        }
+      }
+    }
+
+    loadTopics()
+
+    return () => {
+      isMounted = false
+    }
+  }, [language])
 
   return (
     <div className="min-h-screen bg-slate-100 text-slate-900">

--- a/src/context/AdminAuthContext.jsx
+++ b/src/context/AdminAuthContext.jsx
@@ -1,0 +1,96 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { getAdminSession, signInAdmin } from '../lib/adminApi'
+
+const ADMIN_AUTH_TOKEN_STORAGE_KEY = 'flashboard_admin_token'
+
+const AdminAuthContext = createContext(null)
+
+export function AdminAuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem(ADMIN_AUTH_TOKEN_STORAGE_KEY) || '')
+  const [isAuthenticated, setIsAuthenticated] = useState(Boolean(token))
+  const [isCheckingSession, setIsCheckingSession] = useState(Boolean(token))
+
+  useEffect(() => {
+    let isMounted = true
+
+    const verifySession = async () => {
+      if (!token) {
+        setIsAuthenticated(false)
+        setIsCheckingSession(false)
+        return
+      }
+
+      setIsCheckingSession(true)
+
+      try {
+        await getAdminSession(token)
+
+        if (isMounted) {
+          setIsAuthenticated(true)
+        }
+      } catch {
+        localStorage.removeItem(ADMIN_AUTH_TOKEN_STORAGE_KEY)
+
+        if (isMounted) {
+          setToken('')
+          setIsAuthenticated(false)
+        }
+      } finally {
+        if (isMounted) {
+          setIsCheckingSession(false)
+        }
+      }
+    }
+
+    verifySession()
+
+    return () => {
+      isMounted = false
+    }
+  }, [token])
+
+  const signIn = async (username, password) => {
+    try {
+      const session = await signInAdmin({ username, password })
+      localStorage.setItem(ADMIN_AUTH_TOKEN_STORAGE_KEY, session.token)
+      setToken(session.token)
+      setIsAuthenticated(true)
+
+      return { success: true }
+    } catch (error) {
+      return {
+        success: false,
+        message: error.message || 'Invalid username or password'
+      }
+    }
+  }
+
+  const signOut = () => {
+    localStorage.removeItem(ADMIN_AUTH_TOKEN_STORAGE_KEY)
+    setToken('')
+    setIsAuthenticated(false)
+  }
+
+  const value = useMemo(
+    () => ({
+      token,
+      isAuthenticated,
+      isCheckingSession,
+      signIn,
+      signOut
+    }),
+    [token, isAuthenticated, isCheckingSession]
+  )
+
+  return <AdminAuthContext.Provider value={value}>{children}</AdminAuthContext.Provider>
+}
+
+export function useAdminAuth() {
+  const context = useContext(AdminAuthContext)
+
+  if (!context) {
+    throw new Error('useAdminAuth must be used inside AdminAuthProvider')
+  }
+
+  return context
+}

--- a/src/lib/adminApi.js
+++ b/src/lib/adminApi.js
@@ -1,0 +1,125 @@
+import { apiRequest, extractCollection, extractEntity } from './apiClient'
+
+export async function signInAdmin({ username, password }) {
+  const response = await apiRequest('/admin/sign-in', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ username, password })
+  })
+
+  const token =
+    response?.token ||
+    response?.data?.token ||
+    response?.data?.accessToken ||
+    response?.accessToken
+
+  const admin = response?.admin || response?.data?.admin || null
+
+  if (!token) {
+    throw new Error('Sign-in succeeded but no token was returned by the server.')
+  }
+
+  return { token, admin, raw: response }
+}
+
+export async function getAdminSession(token) {
+  return apiRequest('/admin/me', {
+    method: 'GET',
+    token
+  })
+}
+
+export async function getBlogs() {
+  const response = await apiRequest('/blogs', { method: 'GET' })
+  return extractCollection(response)
+}
+
+export async function createBlog(blog, token) {
+  const response = await apiRequest('/blogs', {
+    method: 'POST',
+    token,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(blog)
+  })
+
+  return extractEntity(response)
+}
+
+export async function updateBlog(id, blog, token) {
+  const response = await apiRequest(`/blogs/${id}`, {
+    method: 'PUT',
+    token,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(blog)
+  })
+
+  return extractEntity(response)
+}
+
+export async function deleteBlog(id, token) {
+  return apiRequest(`/blogs/${id}`, {
+    method: 'DELETE',
+    token
+  })
+}
+
+export async function getCategories() {
+  const response = await apiRequest('/categories', { method: 'GET' })
+  return extractCollection(response)
+}
+
+export async function createCategory(category, token) {
+  const response = await apiRequest('/categories', {
+    method: 'POST',
+    token,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(category)
+  })
+
+  return extractEntity(response)
+}
+
+export async function getTopics() {
+  const response = await apiRequest('/topics', { method: 'GET' })
+  return extractCollection(response)
+}
+
+export async function createTopic(topic, token) {
+  const response = await apiRequest('/topics', {
+    method: 'POST',
+    token,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(topic)
+  })
+
+  return extractEntity(response)
+}
+
+export async function uploadAdminImage(file, token) {
+  const formData = new FormData()
+  formData.append('image', file)
+
+  const response = await apiRequest('/images/upload', {
+    method: 'POST',
+    token,
+    body: formData
+  })
+
+  const payload = extractEntity(response) || response
+
+  if (!payload?.url) {
+    throw new Error('Image upload succeeded but image URL was not returned by the server.')
+  }
+
+  return payload
+}

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -1,0 +1,79 @@
+const DEFAULT_API_BASE_URL = 'http://localhost:5001/api'
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || DEFAULT_API_BASE_URL).replace(/\/$/, '')
+
+function buildHeaders(token, customHeaders = {}) {
+  const headers = {
+    ...customHeaders
+  }
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  return headers
+}
+
+export async function apiRequest(path, options = {}) {
+  const { token, headers, ...restOptions } = options
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...restOptions,
+    headers: buildHeaders(token, headers)
+  })
+
+  const contentType = response.headers.get('content-type') || ''
+  const isJson = contentType.includes('application/json')
+  const body = isJson ? await response.json() : await response.text()
+
+  if (!response.ok) {
+    const errorMessage =
+      (isJson && (body.message || body.error)) ||
+      `Request failed with status ${response.status}`
+
+    const error = new Error(errorMessage)
+    error.status = response.status
+    error.body = body
+    throw error
+  }
+
+  return body
+}
+
+export function extractCollection(payload) {
+  if (Array.isArray(payload)) {
+    return payload
+  }
+
+  if (Array.isArray(payload?.data)) {
+    return payload.data
+  }
+
+  if (Array.isArray(payload?.items)) {
+    return payload.items
+  }
+
+  return []
+}
+
+export function extractEntity(payload) {
+  if (!payload) {
+    return null
+  }
+
+  if (payload.data && typeof payload.data === 'object') {
+    return payload.data
+  }
+
+  if (typeof payload === 'object') {
+    return payload
+  }
+
+  return null
+}
+
+export function getEntityId(entity) {
+  return entity?._id || entity?.id || entity?.slug
+}
+
+export { API_BASE_URL }

--- a/src/lib/publicApi.js
+++ b/src/lib/publicApi.js
@@ -1,0 +1,157 @@
+import { apiRequest, extractCollection, extractEntity, getEntityId } from './apiClient'
+
+function pickLocalizedValue(value, language, fallbackKeys = []) {
+  if (!value) {
+    return ''
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (typeof value === 'object') {
+    if (value[language]) {
+      return value[language]
+    }
+
+    for (const key of fallbackKeys) {
+      if (value[key]) {
+        return value[key]
+      }
+    }
+  }
+
+  return ''
+}
+
+function normalizeTopicTitle(topic, language) {
+  return (
+    pickLocalizedValue(topic.name, language, ['en', 'si']) ||
+    pickLocalizedValue(topic.title, language, ['en', 'si']) ||
+    (language === 'si' ? topic.si : topic.en) ||
+    topic.name ||
+    topic.title ||
+    'Topic'
+  )
+}
+
+function normalizeTopicItems(topic, language) {
+  const rawItems = topic.items || topic.articles || topic.articleItems || []
+
+  return rawItems
+    .map((item) => {
+      const title =
+        pickLocalizedValue(item.title, language, ['en', 'si']) ||
+        item.title ||
+        item[language]?.title ||
+        item.en?.title ||
+        item.si?.title ||
+        ''
+
+      const slug = item.slug || item.articleSlug || item.id || item._id
+
+      if (!title || !slug) {
+        return null
+      }
+
+      return { title, slug }
+    })
+    .filter(Boolean)
+}
+
+export async function getPublicTopics(language) {
+  const response = await apiRequest(`/topics?lang=${language}`, { method: 'GET' })
+  const topics = extractCollection(response)
+
+  return topics
+    .map((topic) => ({
+      id: getEntityId(topic),
+      title: normalizeTopicTitle(topic, language),
+      items: normalizeTopicItems(topic, language)
+    }))
+    .filter((topic) => topic.items.length > 0)
+}
+
+export async function getPublicArticle(slug, language) {
+  const response = await apiRequest(`/articles/${slug}?lang=${language}`, { method: 'GET' })
+  const article = extractEntity(response)
+
+  if (!article) {
+    return null
+  }
+
+  const localized = article[language] || article
+
+  return {
+    id: getEntityId(article),
+    slug: article.slug || slug,
+    title: localized.title || article.title || '',
+    category: localized.category || article.category || '',
+    topic: localized.topic || article.topic || '',
+    image: localized.image || article.image || null,
+    body: localized.body || article.body || ''
+  }
+}
+
+function normalizeBlogEntity(blog, language) {
+  if (!blog) {
+    return null
+  }
+
+  return {
+    id: getEntityId(blog),
+    slug: blog.slug || String(getEntityId(blog) || ''),
+    title: language === 'si' ? blog.titleSi || blog.title || '' : blog.title || blog.titleSi || '',
+    category: language === 'si' ? blog.categorySi || blog.category || '' : blog.category || blog.categorySi || '',
+    topic: language === 'si' ? blog.topicSi || blog.topic || '' : blog.topic || blog.topicSi || '',
+    image: blog.image || null,
+    body: language === 'si' ? blog.contentSi || blog.content || '' : blog.content || blog.contentSi || '',
+    date: blog.date || blog.createdAt || ''
+  }
+}
+
+export async function getPublicBlogs(language) {
+  const response = await apiRequest('/blogs', { method: 'GET' })
+  const blogs = extractCollection(response)
+
+  return blogs
+    .map((blog) => normalizeBlogEntity(blog, language))
+    .filter((blog) => blog && blog.slug && blog.title)
+}
+
+export async function getPublicBlogByIdentifier(identifier, language) {
+  try {
+    const response = await apiRequest(`/blogs/${identifier}`, { method: 'GET' })
+    const blog = extractEntity(response)
+    return normalizeBlogEntity(blog, language)
+  } catch (error) {
+    if (error?.status === 404) {
+      return null
+    }
+
+    throw error
+  }
+}
+
+export async function getPublicBlogSections(language) {
+  const blogs = await getPublicBlogs(language)
+  const groupedMap = new Map()
+
+  blogs.forEach((blog) => {
+    const sectionTitle = blog.category || (language === 'si' ? 'වෙනත්' : 'Other')
+
+    if (!groupedMap.has(sectionTitle)) {
+      groupedMap.set(sectionTitle, [])
+    }
+
+    groupedMap.get(sectionTitle).push({
+      slug: blog.slug,
+      title: blog.title
+    })
+  })
+
+  return Array.from(groupedMap.entries()).map(([title, items]) => ({
+    title,
+    items
+  }))
+}


### PR DESCRIPTION
Integrates backend-driven admin and public content flows: adds AdminAuthContext for token/session management and a new AdminSignIn page with protected admin routes in App. Introduces a generic apiClient (apiRequest, extractCollection/entity, getEntityId) and two API wrappers (adminApi.js and publicApi.js) to handle admin CRUD, image uploads and public blog/topic/article fetching/normalization. Refactors Adminpanel to load/save/delete blogs, categories and topics via adminApi, supports rich-text image uploads from editors, and shows loading/error states. BlogReader and Homepage now fetch sections and articles from the public API with fallbacks to local data. Also adds .env.example (VITE_API_BASE_URL) to configure the API base URL.